### PR TITLE
Add error handling to avoid index-out-of-range 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+.idea
+.vscode

--- a/reader.go
+++ b/reader.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/amsokol/go-grib2/internal"
 	"github.com/pkg/errors"
+	"log"
 )
 
 // GRIB2 is simplified GRIB2 file structure
@@ -89,6 +90,9 @@ func Read(data []byte) ([]GRIB2, error) {
 					return nil, errors.Wrapf(err, "Failed to get longitude and latitude")
 				}
 				raw, err := internal.UnpackData(sections)
+				if err != nil {
+					log.Fatal(err)
+				}
 				c := len(lon)
 				v := make([]Value, c, c)
 				for i := 0; i < c; i++ {

--- a/reader.go
+++ b/reader.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/amsokol/go-grib2/internal"
 	"github.com/pkg/errors"
-	"log"
 )
 
 // GRIB2 is simplified GRIB2 file structure
@@ -91,7 +90,7 @@ func Read(data []byte) ([]GRIB2, error) {
 				}
 				raw, err := internal.UnpackData(sections)
 				if err != nil {
-					log.Fatal(err)
+					return nil, errors.Wrapf(err, "Failed to unpack data")
 				}
 				c := len(lon)
 				v := make([]Value, c, c)


### PR DESCRIPTION
Add error handling to avoid index-out-of-range  when packaging is unsupported. 

Cool library! I might join forces on this to support the compex packaging :)